### PR TITLE
Create address index screen that is publicly visible

### DIFF
--- a/components/TokenSearchResult.tsx
+++ b/components/TokenSearchResult.tsx
@@ -8,11 +8,13 @@ export default function TokenSearchResult({
   token,
   avaliable,
   valid,
+  loggedIn,
 }: {
   name: string
   token: Metadata | undefined
   avaliable: boolean
   valid: boolean
+  loggedIn: boolean
 }) {
   return (
     <div>
@@ -58,21 +60,31 @@ export default function TokenSearchResult({
           }
         }
       />
-      {avaliable ? (
-        valid ? (
+      {loggedIn ? (
+        avaliable ? (
+          valid ? (
+            <div className="p-1">
+              <Link href={`/tokens/mint/${name}`} passHref>
+                <a className="btn btn-outline mt-6">
+                  <p className="font-bold flex">{`Mint your new id`}</p>
+                </a>
+              </Link>
+            </div>
+          ) : null
+        ) : (
           <div className="p-1">
-            <Link href={`/ids/mint/${name}`} passHref>
+            <Link href={`/tokens/${name}`} passHref>
               <a className="btn btn-outline mt-6">
-                <p className="font-bold flex">{`Mint your new id`}</p>
+                <p className="font-bold flex">{`View`}</p>
               </a>
             </Link>
           </div>
-        ) : null
+        )
       ) : (
         <div className="p-1">
           <Link href={`/ids/${name}`} passHref>
             <a className="btn btn-outline mt-6">
-              <p className="font-bold flex">{`View token`}</p>
+              <p className="font-bold flex">{`View`}</p>
             </a>
           </Link>
         </div>

--- a/hooks/cosmwasm.tsx
+++ b/hooks/cosmwasm.tsx
@@ -1,6 +1,9 @@
 import { useState } from 'react'
 import { connectKeplr } from 'services/keplr'
-import { SigningCosmWasmClient } from '@cosmjs/cosmwasm-stargate'
+import {
+  SigningCosmWasmClient,
+  CosmWasmClient,
+} from '@cosmjs/cosmwasm-stargate'
 
 export interface ISigningCosmWasmClientContext {
   walletAddress: string
@@ -69,4 +72,9 @@ export const useSigningCosmWasmClient = (): ISigningCosmWasmClientContext => {
     connectWallet,
     disconnect,
   }
+}
+
+export const getNonSigningClient = async () => {
+  const client = await CosmWasmClient.connect(PUBLIC_RPC_ENDPOINT)
+  return client
 }

--- a/hooks/token.tsx
+++ b/hooks/token.tsx
@@ -26,7 +26,7 @@ export function useToken(tokenId: string) {
         setToken(tokenInfo.extension)
         setLoading(false)
       } catch (e) {
-        console.error(e.error)
+        console.log(e)
       }
     }
 

--- a/hooks/tokens.tsx
+++ b/hooks/tokens.tsx
@@ -25,7 +25,7 @@ export function useTokenList() {
         setTokens(tokenList.tokens)
         setLoading(false)
       } catch (e) {
-        console.error(e.error)
+        console.log(e)
       }
     }
 

--- a/pages/addresses/[address].tsx
+++ b/pages/addresses/[address].tsx
@@ -1,14 +1,110 @@
+import { useState, useEffect } from 'react'
 import type { NextPage } from 'next'
 import Link from 'next/link'
 import PageLink from 'components/PageLink'
-import WalletLoader from 'components/WalletLoader'
+import { getNonSigningClient } from 'hooks/cosmwasm'
+import { useRouter } from 'next/dist/client/router'
+import Loader from 'components/Loader'
+// import WalletLoader from 'components/WalletLoader'
 
 // I guess we want to use the TokenList component in here
 const ListUsernames: NextPage = () => {
+  const router = useRouter()
+  const contract = process.env.NEXT_PUBLIC_WHOAMI_ADDRESS as string
+
+  const address = router.query.address as string
+
+  const [alias, setAlias] = useState<string>()
+  const [loading, setLoading] = useState(false)
+
+  useEffect(() => {
+    if (!address) return
+
+    const getAlias = async () => {
+      setLoading(true)
+
+      console.log(address)
+
+      try {
+        const client = await getNonSigningClient()
+        let aliasResponse = await client.queryContractSmart(contract, {
+          primary_alias: {
+            address: address,
+          },
+        })
+        setAlias(aliasResponse.username)
+        setLoading(false)
+      } catch (e) {
+        console.log(e)
+      }
+    }
+
+    getAlias()
+  }, [address])
+
+  const [tokens, setTokens] = useState<Array<string>>([])
+
+  useEffect(() => {
+    if (!address) return
+
+    const getTokens = async () => {
+      setLoading(true)
+      try {
+        const client = await getNonSigningClient()
+        let tokenList = await client.queryContractSmart(contract, {
+          tokens: {
+            owner: address,
+          },
+        })
+        setTokens(tokenList.tokens)
+        setLoading(false)
+      } catch (e) {
+        console.log(e)
+      }
+    }
+
+    getTokens()
+  }, [address])
+
   return (
-    <WalletLoader>
-      <h1 className="text-3xl font-bold">Usernames for this address:</h1>
-    </WalletLoader>
+    <>
+      {!loading && alias ? (
+        <>
+          <h1 className="text-3xl font-bold">
+            Names for <code>{address}</code>
+          </h1>
+          {tokens !== undefined ? (
+            <ul>
+              {tokens.map((token, key) => {
+                return (
+                  <li
+                    className="card bordered border-secondary hover:border-primary p-6 m-8"
+                    key={key}
+                  >
+                    <Link href={`/ids/${token}`} passHref>
+                      <a>
+                        <div className="card-title">
+                          <h3 className="text-2xl font-bold flex">
+                            {token}
+                            {alias === token ? (
+                              <div className="badge ml-2 mt-2">primary</div>
+                            ) : null}
+                          </h3>
+                        </div>
+                      </a>
+                    </Link>
+                  </li>
+                )
+              })}
+            </ul>
+          ) : (
+            <p>No tokens</p>
+          )}
+        </>
+      ) : (
+        <Loader />
+      )}
+    </>
   )
 }
 

--- a/pages/ids/search.tsx
+++ b/pages/ids/search.tsx
@@ -1,8 +1,7 @@
 import type { NextPage } from 'next'
-import WalletLoader from 'components/WalletLoader'
 import NameSearch from 'components/NameSearch'
 import { useEffect, useState } from 'react'
-import { useSigningClient } from 'contexts/cosmwasm'
+import { getNonSigningClient } from 'hooks/cosmwasm'
 import { Metadata } from 'util/types/messages'
 import TokenSearchResult from 'components/TokenSearchResult'
 import Loader from 'components/Loader'
@@ -13,19 +12,15 @@ const Search: NextPage = () => {
   const [token, setToken] = useState<Metadata | undefined>()
   const [loading, setLoading] = useState(false)
 
-  const { signingClient } = useSigningClient()
-
   useEffect(() => {
-    if (!signingClient) {
-      return
-    }
     const contract = process.env.NEXT_PUBLIC_WHOAMI_ADDRESS as string
 
     const doLoad = async (name: string) => {
       setLoading(true)
       try {
+        const client = await getNonSigningClient()
         // If this query fails it means that the token does not exist.
-        const token = await signingClient.queryContractSmart(contract, {
+        const token = await client.queryContractSmart(contract, {
           nft_info: {
             token_id: name,
           },
@@ -40,7 +35,7 @@ const Search: NextPage = () => {
   }, [searchQuery])
 
   return (
-    <WalletLoader>
+    <>
       <h1 className="text-6xl font-bold mb-2">Find a name</h1>
       <NameSearch query={searchQuery} setQuery={setSearchQuery} />
       {searchQuery !== '' ? (
@@ -54,12 +49,13 @@ const Search: NextPage = () => {
                 token={token}
                 avaliable={!token}
                 valid={searchQuery.length < 21 ? true : false}
+                loggedIn={false}
               />
             )}
           </div>
         </>
       ) : null}
-    </WalletLoader>
+    </>
   )
 }
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -2,27 +2,27 @@ import type { NextPage } from 'next'
 import Link from 'next/link'
 import WalletLoader from 'components/WalletLoader'
 import PageLink from 'components/PageLink'
-import { useSigningClient } from 'contexts/cosmwasm'
+//import { useSigningClient } from 'contexts/cosmwasm'
 import { LibraryIcon, MapIcon, PencilIcon } from '@heroicons/react/solid'
 
 const Home: NextPage = () => {
-  const { walletAddress } = useSigningClient()
+  //const { walletAddress } = useSigningClient()
 
   return (
-    <WalletLoader>
+    <>
       <h1 className="text-6xl font-bold">
         {process.env.NEXT_PUBLIC_SITE_TITLE}
       </h1>
       <p className="italic">Decentralized Name Service</p>
 
       <PageLink
-        href="/ids/register"
+        href="/tokens/register"
         title="Register"
         description="Register and configure a new name"
         Icon={LibraryIcon}
       />
       <PageLink
-        href="/ids/manage"
+        href="/tokens/manage"
         title="Manage"
         description="Transfer, edit, or burn a name that you own"
         Icon={PencilIcon}
@@ -33,7 +33,7 @@ const Home: NextPage = () => {
         description="Lookup addresses and explore registered names"
         Icon={MapIcon}
       />
-    </WalletLoader>
+    </>
   )
 }
 

--- a/pages/tokens/[name]/burn.tsx
+++ b/pages/tokens/[name]/burn.tsx
@@ -41,7 +41,7 @@ const BurnToken: NextPage = () => {
         defaultMemo
       )
       if (updatedToken) {
-        router.push(`/ids/manage`)
+        router.push(`/tokens/manage`)
       }
     } catch (e) {
       // TODO env var for dev logging

--- a/pages/tokens/[name]/index.tsx
+++ b/pages/tokens/[name]/index.tsx
@@ -1,0 +1,112 @@
+import type { NextPage } from 'next'
+import WalletLoader from 'components/WalletLoader'
+import { NameCard } from 'components/NameCard'
+import { useSigningClient } from 'contexts/cosmwasm'
+import { useToken } from 'hooks/token'
+import { usePrimaryAlias } from 'hooks/primaryAlias'
+import { defaultExecuteFee } from 'util/fee'
+import { defaultMemo } from 'util/memo'
+import { useRouter } from 'next/dist/client/router'
+import Link from 'next/link'
+import { useForm } from 'react-hook-form'
+import { Metadata } from 'util/types/messages'
+import { useTokenList } from 'hooks/tokens'
+
+const TokenView: NextPage = () => {
+  const { walletAddress, signingClient } = useSigningClient()
+  const contractAddress = process.env.NEXT_PUBLIC_WHOAMI_ADDRESS as string
+  const router = useRouter()
+  const tokenName = router.query.name as string
+  const { token } = useToken(tokenName)
+  const { tokens } = useTokenList()
+  const { alias, loadingAlias } = usePrimaryAlias()
+
+  const { register, handleSubmit } = useForm()
+
+  const onSubmit = async () => {
+    if (!signingClient) {
+      return
+    }
+
+    const msg = {
+      update_primary_alias: {
+        token_id: tokenName,
+      },
+    }
+
+    try {
+      let updatedToken = await signingClient.execute(
+        walletAddress,
+        contractAddress,
+        msg,
+        defaultExecuteFee,
+        defaultMemo
+      )
+      if (updatedToken) {
+        router.push(`/tokens/manage`)
+      }
+    } catch (e) {
+      // TODO env var for dev logging
+      // console.log(e)
+    }
+  }
+
+  if (!tokenName) {
+    return null
+  }
+
+  return (
+    <WalletLoader>
+      {token ? (
+        <>
+          <NameCard name={tokenName} token={token as Metadata} />
+          <div className="flex flex-wrap">
+            <div className="p-1">
+              <Link href={`/tokens/manage`} passHref>
+                <a className="btn btn-outline mt-6">
+                  <p className="font-bold flex">{`< Back`}</p>
+                </a>
+              </Link>
+            </div>
+
+            <div className="p-1">
+              <Link href={`/tokens/${tokenName}/update`} passHref>
+                <a className="btn btn-outline mt-6">
+                  <p className="font-bold flex">{`Update metadata`}</p>
+                </a>
+              </Link>
+            </div>
+
+            {(alias as string) !== tokenName &&
+            '' !== tokenName &&
+            signingClient ? (
+              <div className="p-1">
+                <form onSubmit={handleSubmit(onSubmit)}>
+                  <input
+                    type="submit"
+                    className="btn btn-outline mt-6"
+                    value="Set as primary"
+                  />
+                </form>
+              </div>
+            ) : null}
+
+            {tokenName && tokens && tokens.includes(tokenName) ? (
+              <div className="p-1">
+                <Link href={`/tokens/${tokenName}/burn`} passHref>
+                  <a className="btn btn-outline mt-6">
+                    <p className="font-bold flex">{`Burn`}</p>
+                  </a>
+                </Link>
+              </div>
+            ) : null}
+          </div>
+        </>
+      ) : (
+        <h1 className="text-6xl font-bold">Not found</h1>
+      )}
+    </WalletLoader>
+  )
+}
+
+export default TokenView

--- a/pages/tokens/manage.tsx
+++ b/pages/tokens/manage.tsx
@@ -26,7 +26,7 @@ const Manage: NextPage = () => {
                 className="card bordered border-secondary hover:border-primary p-6 m-8"
                 key={key}
               >
-                <Link href={`/ids/${token}`} passHref>
+                <Link href={`/tokens/${token}`} passHref>
                   <a>
                     <div className="card-title">
                       <h3 className="text-2xl font-bold flex">

--- a/pages/tokens/register.tsx
+++ b/pages/tokens/register.tsx
@@ -53,6 +53,7 @@ const Register: NextPage = () => {
                 token={token}
                 avaliable={!token}
                 valid={searchQuery.length < 21 ? true : false}
+                loggedIn={true}
               />
             )}
           </div>


### PR DESCRIPTION
Closes #6 
Closes #28 

This:

- Adds an address screen to look up all the aliases for an address
- Adds a public token view screen
- Adds a version of register/search geared towards public lookup
- Changes `/tokens/` to be for token mgmt/logged in experience, and `/ids/` to be for public viewing

