### PR TITLE
Use zustand for state management

### DIFF
--- a/components/Nav.tsx
+++ b/components/Nav.tsx
@@ -21,9 +21,13 @@ function Nav() {
   const setNonSigningClient = useStore((state) => state.setNonSigningClient)
 
   // on first load, init the non signing client
-  useEffect(async () => {
-    const nonSigningClient = await getNonSigningClient()
-    setNonSigningClient(nonSigningClient)
+  useEffect(() => {
+    const initNonSigningClient = async () => {
+      const nonSigningClient = await getNonSigningClient()
+      setNonSigningClient(nonSigningClient)
+    }
+
+    initNonSigningClient()
   }, [])
 
   useEffect(() => {
@@ -34,17 +38,17 @@ function Nav() {
 
   const { connectWallet, disconnect, signingClient } = useSigningClient()
   const handleConnect = () => {
-    if (walletAddress.length === 0) {
+    if (!walletAddress || walletAddress.length === 0) {
       connectWallet()
     } else {
       disconnect()
-      setAlias(undefined)
+      setAlias(null)
     }
   }
 
   const reconnect = useCallback(() => {
     disconnect()
-    setAlias(undefined)
+    setAlias(null)
     connectWallet()
   }, [disconnect, connectWallet])
 
@@ -74,7 +78,7 @@ function Nav() {
         setDirty(false)
       } catch (e) {
         setLoading(false)
-        setAlias(undefined)
+        setAlias(null)
         // console.log(e)
         return
       }

--- a/components/Nav.tsx
+++ b/components/Nav.tsx
@@ -28,7 +28,7 @@ function Nav() {
     }
 
     initNonSigningClient()
-  }, [])
+  }, [setNonSigningClient])
 
   useEffect(() => {
     if (router.query.tokensAltered) {
@@ -50,7 +50,7 @@ function Nav() {
     disconnect()
     setAlias(null)
     connectWallet()
-  }, [disconnect, connectWallet])
+  }, [disconnect, connectWallet, setAlias])
 
   useEffect(() => {
     window.addEventListener('keplr_keystorechange', reconnect)
@@ -85,7 +85,7 @@ function Nav() {
     }
 
     getAlias()
-  }, [alias, walletAddress, contract, signingClient, dirty])
+  }, [alias, walletAddress, contract, signingClient, dirty, setAlias])
 
   const PUBLIC_SITE_ICON_URL = process.env.NEXT_PUBLIC_SITE_ICON_URL || ''
 

--- a/components/Nav.tsx
+++ b/components/Nav.tsx
@@ -5,13 +5,26 @@ import ThemeToggle from 'components/ThemeToggle'
 import { useEffect, useState, useCallback } from 'react'
 import { useRouter } from 'next/dist/client/router'
 import { InboxInIcon } from '@heroicons/react/solid'
+import { useStore } from 'store/base'
+import { getNonSigningClient } from 'hooks/cosmwasm'
 
 function Nav() {
   const router = useRouter()
   const contract = process.env.NEXT_PUBLIC_WHOAMI_ADDRESS as string
-  const [alias, setAlias] = useState<string | undefined>()
+  // const [alias, setAlias] = useState<string | undefined>()
   const [loading, setLoading] = useState(false)
   const [dirty, setDirty] = useState(false)
+
+  const walletAddress = useStore((state) => state.walletAddress)
+  const alias = useStore((state) => state.primaryAlias)
+  const setAlias = useStore((state) => state.setPrimaryAlias)
+  const setNonSigningClient = useStore((state) => state.setNonSigningClient)
+
+  // on first load, init the non signing client
+  useEffect(async () => {
+    const nonSigningClient = await getNonSigningClient()
+    setNonSigningClient(nonSigningClient)
+  }, [])
 
   useEffect(() => {
     if (router.query.tokensAltered) {
@@ -19,8 +32,7 @@ function Nav() {
     }
   }, [router.query.tokensAltered])
 
-  const { walletAddress, connectWallet, disconnect, signingClient } =
-    useSigningClient()
+  const { connectWallet, disconnect, signingClient } = useSigningClient()
   const handleConnect = () => {
     if (walletAddress.length === 0) {
       connectWallet()

--- a/components/Nav.tsx
+++ b/components/Nav.tsx
@@ -11,9 +11,7 @@ import { getNonSigningClient } from 'hooks/cosmwasm'
 function Nav() {
   const router = useRouter()
   const contract = process.env.NEXT_PUBLIC_WHOAMI_ADDRESS as string
-  // const [alias, setAlias] = useState<string | undefined>()
   const [loading, setLoading] = useState(false)
-  const [dirty, setDirty] = useState(false)
 
   const walletAddress = useStore((state) => state.walletAddress)
   const alias = useStore((state) => state.primaryAlias)
@@ -29,12 +27,6 @@ function Nav() {
 
     initNonSigningClient()
   }, [setNonSigningClient])
-
-  useEffect(() => {
-    if (router.query.tokensAltered) {
-      setDirty(true)
-    }
-  }, [router.query.tokensAltered])
 
   const { connectWallet, disconnect, signingClient } = useSigningClient()
   const handleConnect = () => {
@@ -75,7 +67,6 @@ function Nav() {
         })
         setAlias(aliasResponse.username)
         setLoading(false)
-        setDirty(false)
       } catch (e) {
         setLoading(false)
         setAlias(null)
@@ -85,7 +76,7 @@ function Nav() {
     }
 
     getAlias()
-  }, [alias, walletAddress, contract, signingClient, dirty, setAlias])
+  }, [alias, walletAddress, contract, signingClient, setAlias])
 
   const PUBLIC_SITE_ICON_URL = process.env.NEXT_PUBLIC_SITE_ICON_URL || ''
 

--- a/components/Send.tsx
+++ b/components/Send.tsx
@@ -38,7 +38,7 @@ export function Send({
   const [memo, setMemo] = useState(defaultMemo)
 
   useEffect(() => {
-    if (!signingClient || walletAddress.length === 0) {
+    if (!signingClient || !walletAddress || walletAddress.length === 0) {
       return
     }
     setError('')
@@ -76,7 +76,7 @@ export function Send({
 
     try {
       let res = await signingClient.sendTokens(
-        walletAddress,
+        walletAddress!,
         recipientAddress,
         amount,
         defaultExecuteFee,

--- a/components/WalletLoader.tsx
+++ b/components/WalletLoader.tsx
@@ -2,6 +2,7 @@ import { ReactNode, useState, useEffect } from 'react'
 import { useSigningClient } from 'contexts/cosmwasm'
 import Loader from './Loader'
 import { isKeplrInstalled } from 'services/keplr'
+import { useStore } from 'store/base'
 
 function WalletLoader({
   children,
@@ -10,12 +11,10 @@ function WalletLoader({
   children: ReactNode
   loading?: boolean
 }) {
-  const {
-    walletAddress,
-    loading: clientLoading,
-    error,
-    connectWallet,
-  } = useSigningClient()
+  const { loading: clientLoading, error, connectWallet } = useSigningClient()
+
+  const walletAddress = useStore((state) => state.walletAddress)
+  const signingClient = useStore((state) => state.signingClient)
 
   const [keplrInstalled, setKeplrInstalled] = useState<boolean | undefined>()
 
@@ -31,7 +30,7 @@ function WalletLoader({
     )
   }
 
-  if (walletAddress === '') {
+  if (!signingClient) {
     const actionText = keplrInstalled ? (
       <>
         <p>Please connect your Keplr wallet to continue</p>

--- a/hooks/cosmwasm.tsx
+++ b/hooks/cosmwasm.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { useStore } from 'store/base'
 import { connectKeplr } from 'services/keplr'
 import {
   SigningCosmWasmClient,
@@ -18,11 +19,16 @@ const PUBLIC_RPC_ENDPOINT = process.env.NEXT_PUBLIC_CHAIN_RPC_ENDPOINT || ''
 const PUBLIC_CHAIN_ID = process.env.NEXT_PUBLIC_CHAIN_ID
 
 export const useSigningCosmWasmClient = (): ISigningCosmWasmClientContext => {
-  const [walletAddress, setWalletAddress] = useState('')
-  const [signingClient, setSigningClient] =
-    useState<SigningCosmWasmClient | null>(null)
+  //const [walletAddress, setWalletAddress] = useState('')
+  // const [signingClient, setSigningClient] =
+  //  useState<SigningCosmWasmClient | null>(null)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState(null)
+
+  const setSigningClient = useStore((state) => state.setSigningClient)
+  const setStoreWalletAddress = useStore((state) => state.setWalletAddress)
+  const walletAddress = useStore((state) => state.walletAddress)
+  const signingClient = useStore((state) => state.signingClient)
 
   const connectWallet = async () => {
     setLoading(true)
@@ -47,7 +53,7 @@ export const useSigningCosmWasmClient = (): ISigningCosmWasmClientContext => {
 
       // get user address
       const [{ address }] = await offlineSigner.getAccounts()
-      setWalletAddress(address)
+      setStoreWalletAddress(address)
 
       setLoading(false)
     } catch (error) {
@@ -59,7 +65,7 @@ export const useSigningCosmWasmClient = (): ISigningCosmWasmClientContext => {
     if (signingClient) {
       signingClient.disconnect()
     }
-    setWalletAddress('')
+    setStoreWalletAddress('')
     setSigningClient(null)
     setLoading(false)
   }

--- a/hooks/cosmwasm.tsx
+++ b/hooks/cosmwasm.tsx
@@ -5,9 +5,10 @@ import {
   SigningCosmWasmClient,
   CosmWasmClient,
 } from '@cosmjs/cosmwasm-stargate'
+import { OptionString } from 'util/types/base'
 
 export interface ISigningCosmWasmClientContext {
-  walletAddress: string
+  walletAddress: OptionString
   signingClient: SigningCosmWasmClient | null
   loading: boolean
   error: any
@@ -53,6 +54,8 @@ export const useSigningCosmWasmClient = (): ISigningCosmWasmClientContext => {
 
       // get user address
       const [{ address }] = await offlineSigner.getAccounts()
+
+      // this will definitely be set to string
       setStoreWalletAddress(address)
 
       setLoading(false)

--- a/hooks/primaryAlias.tsx
+++ b/hooks/primaryAlias.tsx
@@ -1,13 +1,18 @@
 import { useSigningClient } from 'contexts/cosmwasm'
 import { useEffect, useState } from 'react'
+import { useStore } from 'store/base'
 
 export function usePrimaryAlias() {
   const contract = process.env.NEXT_PUBLIC_WHOAMI_ADDRESS as string
 
-  const [alias, setAlias] = useState<string | undefined>()
+  const setPrimaryAlias = useStore((state) => state.setPrimaryAlias)
+  const alias = useStore((state) => state.primaryAlias)
+
+  //const [alias, setAlias] = useState<string | undefined>()
   const [loadingAlias, setLoading] = useState(false)
 
-  const { walletAddress, signingClient } = useSigningClient()
+  const { signingClient } = useSigningClient()
+  const walletAddress = useStore((state) => state.walletAddress)
 
   useEffect(() => {
     if (!signingClient || !walletAddress) {
@@ -22,17 +27,19 @@ export function usePrimaryAlias() {
             address: walletAddress,
           },
         })
-        setAlias(aliasResponse.username)
+        //setAlias(aliasResponse.username)
+        setPrimaryAlias(aliasResponse.username)
         setLoading(false)
       } catch (e) {
         console.error(e.message)
-        setAlias(undefined)
+        //setAlias(undefined)
+        setPrimaryAlias(null)
         return
       }
     }
 
     getAlias()
-  }, [alias, walletAddress])
+  }, [walletAddress])
 
   return { alias, loadingAlias }
 }

--- a/hooks/token.tsx
+++ b/hooks/token.tsx
@@ -1,14 +1,18 @@
 import { useSigningClient } from 'contexts/cosmwasm'
 import { useEffect, useState } from 'react'
 import { Metadata } from 'util/types/messages'
+import { useStore } from 'store/base'
 
-export function useToken(tokenId: string, walletAddress: string) {
+export function useToken(tokenId: string) {
   const contract = process.env.NEXT_PUBLIC_WHOAMI_ADDRESS as string
 
-  const [token, setToken] = useState<Metadata>()
+  const setStoreToken = useStore((state) => state.setToken)
+  const token = useStore((state) => state.token)
+  //const [token, setToken] = useState<Metadata>()
   const [loadingToken, setLoading] = useState(false)
 
   const { signingClient } = useSigningClient()
+  const walletAddress = useStore((state) => state.walletAddress)
 
   useEffect(() => {
     if (!signingClient) {
@@ -23,9 +27,11 @@ export function useToken(tokenId: string, walletAddress: string) {
             token_id: tokenId,
           },
         })
-        setToken(tokenInfo.extension)
+        //setToken(tokenInfo.extension)
+        setStoreToken(tokenInfo.extension)
         setLoading(false)
       } catch (e) {
+        setStoreToken(null)
         console.log(e)
       }
     }

--- a/hooks/tokens.tsx
+++ b/hooks/tokens.tsx
@@ -6,7 +6,7 @@ export function useTokenList() {
   const contract = process.env.NEXT_PUBLIC_WHOAMI_ADDRESS as string
 
   const setStoreTokens = useStore((state) => state.setTokenIds)
-  const tokens = useStore((state) => state.tokens)
+  const tokens: string[] = useStore((state) => state.tokenIds)
 
   //const [tokens, setTokens] = useState<Array<string>>([])
   const [loadingTokens, setLoading] = useState(false)

--- a/hooks/tokens.tsx
+++ b/hooks/tokens.tsx
@@ -1,13 +1,18 @@
 import { useSigningClient } from 'contexts/cosmwasm'
 import { useEffect, useState } from 'react'
+import { useStore } from 'store/base'
 
 export function useTokenList() {
   const contract = process.env.NEXT_PUBLIC_WHOAMI_ADDRESS as string
 
-  const [tokens, setTokens] = useState<Array<string>>([])
+  const setStoreTokens = useStore((state) => state.setTokenIds)
+  const tokens = useStore((state) => state.tokens)
+
+  //const [tokens, setTokens] = useState<Array<string>>([])
   const [loadingTokens, setLoading] = useState(false)
 
-  const { walletAddress, signingClient } = useSigningClient()
+  const { signingClient } = useSigningClient()
+  const walletAddress = useStore((state) => state.walletAddress)
 
   useEffect(() => {
     if (!signingClient || !walletAddress) {
@@ -23,9 +28,11 @@ export function useTokenList() {
             limit: 30,
           },
         })
-        setTokens(tokenList.tokens)
+        //setTokens(tokenList.tokens)
+        setStoreTokens(tokenList.tokens)
         setLoading(false)
       } catch (e) {
+        setStoreTokens([])
         console.log(e)
       }
     }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "rm -r dist || true && next dev",
     "build": "next build",
     "start": "next start",
     "lint": "next lint && prettier --check .",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "react-hook-form": "^7.20.4",
-    "theme-change": "^2.0.2"
+    "theme-change": "^2.0.2",
+    "zustand": "^3.6.9"
   },
   "devDependencies": {
     "@keplr-wallet/types": "^0.9.10",

--- a/pages/ids/search.tsx
+++ b/pages/ids/search.tsx
@@ -8,6 +8,7 @@ import { CopyInput } from 'components/CopyInput'
 import Loader from 'components/Loader'
 import WalletLoader from 'components/WalletLoader'
 import { Send } from 'components/Send'
+import { useStore } from 'store/base'
 
 // TODO - make this functionally distinct from register
 const Search: NextPage = () => {
@@ -19,11 +20,12 @@ const Search: NextPage = () => {
   const [owner, setOwner] = useState<string | undefined>()
   const [showSend, setShowSend] = useState(false)
 
+  const client = useStore((state) => state.nonSigningClient)
+
   useEffect(() => {
     const doLoad = async (name: string) => {
       setLoading(true)
       try {
-        const client = await getNonSigningClient()
         // If this query fails it means that the token does not exist.
         const token = await client.queryContractSmart(contract, {
           nft_info: {
@@ -48,7 +50,6 @@ const Search: NextPage = () => {
     const getOwner = async () => {
       setLoading(true)
       try {
-        const client = await getNonSigningClient()
         let owner = await client.queryContractSmart(contract, {
           owner_of: {
             token_id: tokenName,

--- a/pages/ids/search.tsx
+++ b/pages/ids/search.tsx
@@ -23,17 +23,25 @@ const Search: NextPage = () => {
   const client = useStore((state) => state.nonSigningClient)
 
   useEffect(() => {
+    if (!client) return
+
     const doLoad = async (name: string) => {
       setLoading(true)
       try {
         // If this query fails it means that the token does not exist.
-        const token = await client.queryContractSmart(contract, {
+        const token = await client!.queryContractSmart(contract, {
           nft_info: {
             token_id: name,
           },
         })
-        setToken(token.extension)
-        setTokenName(name)
+
+        if (token) {
+          setToken(token.extension)
+          setTokenName(name)
+        } else {
+          setToken(undefined)
+          setOwner(undefined)
+        }
       } catch (e) {
         setToken(undefined)
         setOwner(undefined)
@@ -45,12 +53,12 @@ const Search: NextPage = () => {
   }, [searchQuery, contract])
 
   useEffect(() => {
-    if (!tokenName) return
+    if (!tokenName || !client) return
 
     const getOwner = async () => {
       setLoading(true)
       try {
-        let owner = await client.queryContractSmart(contract, {
+        let owner = await client!.queryContractSmart(contract, {
           owner_of: {
             token_id: tokenName,
           },

--- a/pages/ids/search.tsx
+++ b/pages/ids/search.tsx
@@ -50,7 +50,7 @@ const Search: NextPage = () => {
       setLoading(false)
     }
     doLoad(searchQuery)
-  }, [searchQuery, contract])
+  }, [searchQuery, contract, client])
 
   useEffect(() => {
     if (!tokenName || !client) return
@@ -73,7 +73,7 @@ const Search: NextPage = () => {
     }
 
     getOwner()
-  }, [tokenName, contract])
+  }, [tokenName, contract, client])
 
   const handleShowSend = () => {
     if (showSend === false) {

--- a/pages/messages.tsx
+++ b/pages/messages.tsx
@@ -40,7 +40,7 @@ const Messages: NextPage = () => {
   >([])
 
   useEffect(() => {
-    if (!signingClient || walletAddress.length === 0) {
+    if (!signingClient || !walletAddress || walletAddress.length === 0) {
       return
     }
 
@@ -89,7 +89,7 @@ const Messages: NextPage = () => {
   }, [signingClient, walletAddress])
 
   useEffect(() => {
-    if (!signingClient || walletAddress.length === 0) {
+    if (!signingClient || !walletAddress || walletAddress.length === 0) {
       return
     }
 
@@ -136,7 +136,7 @@ const Messages: NextPage = () => {
   }, [signingClient, walletAddress, loadedAt, contract, messages])
 
   useEffect(() => {
-    if (!signingClient || walletAddress.length === 0) {
+    if (!signingClient || !walletAddress || walletAddress.length === 0) {
       return
     }
 

--- a/pages/tokens/[name]/burn.tsx
+++ b/pages/tokens/[name]/burn.tsx
@@ -19,7 +19,7 @@ const BurnToken: NextPage = () => {
   const { handleSubmit } = useForm()
   const { signingClient, walletAddress } = useSigningClient()
   const contractAddress = process.env.NEXT_PUBLIC_WHOAMI_ADDRESS as string
-  const { token } = useToken(tokenName, walletAddress)
+  const { token } = useToken(tokenName)
   const [error, setError] = useState()
   const [loading, setLoading] = useState(false)
 
@@ -28,7 +28,7 @@ const BurnToken: NextPage = () => {
   }
 
   const onSubmit = async () => {
-    if (!signingClient) {
+    if (!signingClient || !walletAddress) {
       return
     }
 
@@ -41,7 +41,7 @@ const BurnToken: NextPage = () => {
     }
     try {
       let updatedToken = await signingClient.execute(
-        walletAddress,
+        walletAddress!,
         contractAddress,
         msg,
         defaultExecuteFee,

--- a/pages/tokens/[name]/index.tsx
+++ b/pages/tokens/[name]/index.tsx
@@ -14,13 +14,16 @@ import Link from 'next/link'
 import { useForm } from 'react-hook-form'
 import { Metadata } from 'util/types/messages'
 import { useTokenList } from 'hooks/tokens'
+import { useStore } from 'store/base'
+import * as R from 'ramda'
 
 const TokenView: NextPage = () => {
-  const { walletAddress, signingClient } = useSigningClient()
+  const { signingClient } = useSigningClient()
+  const walletAddress = useStore((state) => state.walletAddress)
   const contractAddress = process.env.NEXT_PUBLIC_WHOAMI_ADDRESS as string
   const router = useRouter()
   const tokenName = router.query.name as string
-  const { token } = useToken(tokenName, walletAddress)
+  const { token } = useToken(tokenName)
   const { tokens } = useTokenList()
   const { alias, loadingAlias } = usePrimaryAlias()
   const [error, setError] = useState()
@@ -37,7 +40,7 @@ const TokenView: NextPage = () => {
   }
 
   const onSubmit = async () => {
-    if (!signingClient) {
+    if (!signingClient || !walletAddress) {
       return
     }
 
@@ -49,7 +52,7 @@ const TokenView: NextPage = () => {
 
     try {
       let updatedToken = await signingClient.execute(
-        walletAddress,
+        walletAddress!,
         contractAddress,
         msg,
         defaultExecuteFee,
@@ -102,7 +105,7 @@ const TokenView: NextPage = () => {
             {(alias as string) !== tokenName &&
             '' !== tokenName &&
             signingClient &&
-            tokens.includes(tokenName) ? (
+            R.includes(tokenName, tokens) ? (
               <div className="p-1">
                 <form onSubmit={handleSubmit(onSubmit)}>
                   <input
@@ -114,7 +117,7 @@ const TokenView: NextPage = () => {
               </div>
             ) : null}
 
-            {tokenName && tokens && tokens.includes(tokenName) ? (
+            {tokenName && tokens && R.includes(tokenName, tokens) ? (
               <>
                 <div className="p-1">
                   <Link href={`/tokens/${tokenName}/update`} passHref>

--- a/pages/tokens/[name]/update.tsx
+++ b/pages/tokens/[name]/update.tsx
@@ -57,7 +57,7 @@ const TokenUpdate: NextPage = () => {
   } = useForm<FormValues>()
 
   useEffect(() => {
-    if (!tokenName || !signingClient) {
+    if (!tokenName || !signingClient || !walletAddress) {
       return
     }
 
@@ -98,7 +98,7 @@ const TokenUpdate: NextPage = () => {
   }, [tokenName, contractAddress, signingClient, reset])
 
   const onSubmit = async (data: FormValues) => {
-    if (!signingClient) {
+    if (!signingClient || !walletAddress) {
       return
     }
 
@@ -139,7 +139,7 @@ const TokenUpdate: NextPage = () => {
 
     try {
       let updatedToken = await signingClient.execute(
-        walletAddress,
+        walletAddress!,
         contractAddress,
         msg,
         defaultExecuteFee,

--- a/pages/tokens/[name]/update.tsx
+++ b/pages/tokens/[name]/update.tsx
@@ -95,7 +95,7 @@ const TokenUpdate: NextPage = () => {
     }
 
     getToken()
-  }, [tokenName, contractAddress, signingClient, reset])
+  }, [tokenName, contractAddress, signingClient, reset, walletAddress])
 
   const onSubmit = async (data: FormValues) => {
     if (!signingClient || !walletAddress) {

--- a/pages/tokens/mint/[name].tsx
+++ b/pages/tokens/mint/[name].tsx
@@ -81,7 +81,7 @@ const Mint: NextPage = () => {
   const humanDenom = R.toUpper(convertDenomToHumanReadableDenom(denom))
 
   const onSubmit = async (data: FormValues) => {
-    if (!signingClient) {
+    if (!signingClient || !walletAddress) {
       return
     }
 
@@ -127,10 +127,8 @@ const Mint: NextPage = () => {
     }
 
     try {
-      // const mintCost = getMintCost(token_id)
-
       let mintedToken = await signingClient.execute(
-        walletAddress,
+        walletAddress!,
         contractAddress,
         msg,
         defaultMintFee,

--- a/pages/tokens/mint/[name].tsx
+++ b/pages/tokens/mint/[name].tsx
@@ -3,6 +3,7 @@ import InputField from 'components/InputField'
 import { useForm, RegisterOptions, FieldError } from 'react-hook-form'
 import { useRouter } from 'next/router'
 import { useState } from 'react'
+import { useStore } from 'store/base'
 import { OptionString } from 'util/types/base'
 import { Metadata } from 'util/types/messages'
 import WalletLoader from 'components/WalletLoader'
@@ -56,6 +57,8 @@ const Mint: NextPage = () => {
   const [token, setToken] = useState(defaults)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState()
+
+  const appendTokenId = useStore((state) => state.appendTokenId)
 
   const {
     register,
@@ -137,10 +140,8 @@ const Mint: NextPage = () => {
       if (mintedToken) {
         router.push({
           pathname: `/tokens/${token_id}`,
-          query: {
-            tokensAltered: true,
-          },
         })
+        appendTokenId(token_id)
         // setLoading(false)
       }
     } catch (e) {

--- a/store/base.ts
+++ b/store/base.ts
@@ -40,48 +40,47 @@ const useStore = create<
   StoreApiWithPersist<State>
 >(
   devtools(
-    persist(
-      (set) =>
-        ({
-          signingClient: null,
-          setSigningClient: (client: SCWClientOrNull) =>
-            set((state) => ({ signingClient: client })),
+    // persist(
+    (set) =>
+      ({
+        signingClient: null,
+        setSigningClient: (client: SCWClientOrNull) =>
+          set((state) => ({ signingClient: client })),
 
-          nonSigningClient: null,
-          setNonSigningClient: (client: CWClientOrNull) =>
-            set((state) => ({ nonSigningClient: client })),
+        nonSigningClient: null,
+        setNonSigningClient: (client: CWClientOrNull) =>
+          set((state) => ({ nonSigningClient: client })),
 
-          primaryAlias: null,
-          setPrimaryAlias: (alias: OptionString) =>
-            set((state) => ({ primaryAlias: alias })),
+        primaryAlias: null,
+        setPrimaryAlias: (alias: OptionString) =>
+          set((state) => ({ primaryAlias: alias })),
 
-          walletAddress: null,
-          setWalletAddress: (address: OptionString) =>
-            set((state) => ({ walletAddress: address })),
+        walletAddress: null,
+        setWalletAddress: (address: OptionString) =>
+          set((state) => ({ walletAddress: address })),
 
-          token: null,
-          setToken: (token: Metadata | null) =>
-            set((state) => ({ token: token })),
+        token: null,
+        setToken: (token: Metadata | null) =>
+          set((state) => ({ token: token })),
 
-          tokenIds: [],
-          appendTokenId: (tokenId: string) =>
-            set((state) => ({ tokenIds: R.append(tokenId, state.tokenIds) })),
+        tokenIds: [],
+        appendTokenId: (tokenId: string) =>
+          set((state) => ({ tokenIds: R.append(tokenId, state.tokenIds) })),
 
-          setTokenIds: (tokenIds: string[]) =>
-            set((state) => ({ tokenIds: tokenIds })),
+        setTokenIds: (tokenIds: string[]) =>
+          set((state) => ({ tokenIds: tokenIds })),
 
-          tokens: [],
-          appendToken: (token: Metadata) =>
-            set((state) => ({ tokens: R.append(token, state.tokens) })),
+        tokens: [],
+        appendToken: (token: Metadata) =>
+          set((state) => ({ tokens: R.append(token, state.tokens) })),
 
-          setTokens: (tokens: Metadata[]) =>
-            set((state) => ({ tokens: tokens })),
-        } as State),
-      {
-        name: 'dens-storage',
-        getStorage: () => localStorage,
-      }
-    )
+        setTokens: (tokens: Metadata[]) => set((state) => ({ tokens: tokens })),
+      } as State) //,
+    //   {
+    //     name: 'dens-storage',
+    //     getStorage: () => localStorage,
+    //   }
+    // )
   )
 )
 

--- a/store/base.ts
+++ b/store/base.ts
@@ -6,6 +6,7 @@ import {
 } from '@cosmjs/cosmwasm-stargate'
 import { Metadata } from 'util/types/messages'
 import { OptionString } from 'util/types/base'
+import * as R from 'ramda'
 
 type SCWClientOrNull = SigningCosmWasmClient | null
 type CWClientOrNull = CosmWasmClient | null
@@ -18,7 +19,7 @@ interface State {
   walletAddress: OptionString
   token: Metadata | null
   tokenIds: string[]
-  tokens: [Metadata[]]
+  tokens: Metadata[]
 
   // functions
   setSigningClient: (c: SCWClientOrNull) => void
@@ -40,29 +41,42 @@ const useStore = create<
 >(
   devtools(
     persist(
-      (set) => ({
-        signingClient: null,
-        setSigningClient: (client) =>
-          set((state) => ({ signingClient: client })),
-        nonSigningClient: null,
-        setNonSigningClient: (client) =>
-          set((state) => ({ nonSigningClient: client })),
-        primaryAlias: null,
-        setPrimaryAlias: (alias) => set((state) => ({ primaryAlias: alias })),
-        walletAddress: null,
-        setWalletAddress: (address) =>
-          set((state) => ({ walletAddress: address })),
-        token: null,
-        setToken: (token) => set((state) => ({ token: token })),
-        tokenIds: [],
-        appendTokenId: (token) =>
-          set((state) => ({ tokens: tokens.push(token) })),
-        setTokenIds: (tokens) => set((state) => ({ tokens: tokens })),
-        tokens: [],
-        appendToken: (token) =>
-          set((state) => ({ tokens: tokens.push(token) })),
-        setTokens: (tokens) => set((state) => ({ tokens: tokens })),
-      }),
+      (set) =>
+        ({
+          signingClient: null,
+          setSigningClient: (client: SCWClientOrNull) =>
+            set((state) => ({ signingClient: client })),
+
+          nonSigningClient: null,
+          setNonSigningClient: (client: CWClientOrNull) =>
+            set((state) => ({ nonSigningClient: client })),
+
+          primaryAlias: null,
+          setPrimaryAlias: (alias: OptionString) =>
+            set((state) => ({ primaryAlias: alias })),
+
+          walletAddress: null,
+          setWalletAddress: (address: OptionString) =>
+            set((state) => ({ walletAddress: address })),
+
+          token: null,
+          setToken: (token: Metadata | null) =>
+            set((state) => ({ token: token })),
+
+          tokenIds: [],
+          appendTokenId: (tokenId: string) =>
+            set((state) => ({ tokenIds: R.append(tokenId, state.tokenIds) })),
+
+          setTokenIds: (tokenIds: string[]) =>
+            set((state) => ({ tokenIds: tokenIds })),
+
+          tokens: [],
+          appendToken: (token: Metadata) =>
+            set((state) => ({ tokens: R.append(token, state.tokens) })),
+
+          setTokens: (tokens: Metadata[]) =>
+            set((state) => ({ tokens: tokens })),
+        } as State),
       {
         name: 'dens-storage',
         getStorage: () => localStorage,
@@ -71,4 +85,4 @@ const useStore = create<
   )
 )
 
-export { useStore, State }
+export { useStore }

--- a/store/base.ts
+++ b/store/base.ts
@@ -1,6 +1,5 @@
-import create from 'zustand'
-import { persist } from 'zustand/middleware'
-import { devtools } from 'zustand/middleware'
+import create, { GetState, SetState } from 'zustand'
+import { persist, StoreApiWithPersist, devtools } from 'zustand/middleware'
 import {
   SigningCosmWasmClient,
   CosmWasmClient,
@@ -33,7 +32,12 @@ interface State {
   setTokens: (ts: Metadata[]) => void
 }
 
-const useStore = create<State>(
+const useStore = create<
+  State,
+  SetState<State>,
+  GetState<State>,
+  StoreApiWithPersist<State>
+>(
   devtools(
     persist(
       (set) => ({

--- a/store/base.ts
+++ b/store/base.ts
@@ -1,8 +1,39 @@
 import create from 'zustand'
 import { persist } from 'zustand/middleware'
 import { devtools } from 'zustand/middleware'
+import {
+  SigningCosmWasmClient,
+  CosmWasmClient,
+} from '@cosmjs/cosmwasm-stargate'
+import { Metadata } from 'util/types/messages'
+import { OptionString } from 'util/types/base'
 
-export const useStore = create(
+type SCWClientOrNull = SigningCosmWasmClient | null
+type CWClientOrNull = CosmWasmClient | null
+
+interface State {
+  // fields
+  signingClient: SCWClientOrNull
+  nonSigningClient: CWClientOrNull
+  primaryAlias: OptionString
+  walletAddress: OptionString
+  token: Metadata | null
+  tokenIds: string[]
+  tokens: [Metadata[]]
+
+  // functions
+  setSigningClient: (c: SCWClientOrNull) => void
+  setNonSigningClient: (c: CWClientOrNull) => void
+  setPrimaryAlias: (alias: OptionString) => void
+  setWalletAddress: (address: string) => void
+  setToken: (t: Metadata | null) => void
+  appendTokenId: (tid: string) => void
+  setTokenIds: (tids: string[]) => void
+  appendToken: (t: Metadata) => void
+  setTokens: (ts: Metadata[]) => void
+}
+
+const useStore = create<State>(
   devtools(
     persist(
       (set) => ({
@@ -35,3 +66,5 @@ export const useStore = create(
     )
   )
 )
+
+export { useStore, State }

--- a/store/base.ts
+++ b/store/base.ts
@@ -1,0 +1,37 @@
+import create from 'zustand'
+import { persist } from 'zustand/middleware'
+import { devtools } from 'zustand/middleware'
+
+export const useStore = create(
+  devtools(
+    persist(
+      (set) => ({
+        signingClient: null,
+        setSigningClient: (client) =>
+          set((state) => ({ signingClient: client })),
+        nonSigningClient: null,
+        setNonSigningClient: (client) =>
+          set((state) => ({ nonSigningClient: client })),
+        primaryAlias: null,
+        setPrimaryAlias: (alias) => set((state) => ({ primaryAlias: alias })),
+        walletAddress: null,
+        setWalletAddress: (address) =>
+          set((state) => ({ walletAddress: address })),
+        token: null,
+        setToken: (token) => set((state) => ({ token: token })),
+        tokenIds: [],
+        appendTokenId: (token) =>
+          set((state) => ({ tokens: tokens.push(token) })),
+        setTokenIds: (tokens) => set((state) => ({ tokens: tokens })),
+        tokens: [],
+        appendToken: (token) =>
+          set((state) => ({ tokens: tokens.push(token) })),
+        setTokens: (tokens) => set((state) => ({ tokens: tokens })),
+      }),
+      {
+        name: 'dens-storage',
+        getStorage: () => localStorage,
+      }
+    )
+  )
+)

--- a/yarn.lock
+++ b/yarn.lock
@@ -4377,3 +4377,8 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+
+zustand@^3.6.9:
+  version "3.6.9"
+  resolved "https://registry.yarnpkg.com/zustand/-/zustand-3.6.9.tgz#f61a756ddea9f95c7ee7cfd3af2f88c10078afbc"
+  integrity sha512-OvDNu/jEWpRnEC7k8xh8GKjqYog7td6FZrLMuHs/IeI8WhrCwV+FngVuwMIFhp5kysZXr6emaeReMqjLGaldAQ==


### PR DESCRIPTION
Attempt to more sensibly manage global state.

Not wild about how subs and events are kind of all in the same state object, but it works p well.

To test before merge:

- [ ] Register page
- [ ] Mint a token (and check if it updates yr alias if it's your first mint)
- [ ] Manage page
- [ ] Landing on a sub page (e.g. manage) while logged out/not wallet connected
- [ ] Public tokens page
- [ ] Search page & send via that page
- [ ] Localstorage persistence works and doesn't result in crazy stale state
- [ ] Switching wallet

Fixes #58 