### PR TITLE
Add API endpoints for Addresses

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@cosmjs/stargate": "^0.27.0",
     "@heroicons/react": "^1.0.5",
     "@vercel/node": "^1.13.0",
+    "bech32": "^2.0.0",
     "daisyui": "^1.14.0",
     "next": "11.1.1",
     "ramda": "^0.27.1",

--- a/pages/api/addresses/[address]/index.ts
+++ b/pages/api/addresses/[address]/index.ts
@@ -1,0 +1,23 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { getNonSigningClient } from 'hooks/cosmwasm'
+import { getJunoAddress } from 'util/conversion'
+import { getTokens } from 'util/query'
+
+// this should handle any cosmos address
+const handler = async (req: VercelRequest, res: VercelResponse) => {
+  const { address } = req.query
+
+  const junoAddress = getJunoAddress(address as string)
+
+  try {
+    const primaryAlias = await getTokens(junoAddress as string)
+    res.statusCode = 200
+    res.setHeader('Content-Type', 'application/json')
+    res.json(primaryAlias)
+  } catch (error) {
+    console.error(error)
+    res.status(error.status || 500).end(error.message)
+  }
+}
+
+export default handler

--- a/pages/api/addresses/[address]/primary.ts
+++ b/pages/api/addresses/[address]/primary.ts
@@ -1,0 +1,23 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { getNonSigningClient } from 'hooks/cosmwasm'
+import { getJunoAddress } from 'util/conversion'
+import { getPrimaryAlias } from 'util/query'
+
+// this should handle any cosmos address
+const handler = async (req: VercelRequest, res: VercelResponse) => {
+  const { address } = req.query
+
+  const junoAddress = getJunoAddress(address as string)
+
+  try {
+    const primaryAlias = await getPrimaryAlias(junoAddress as string)
+    res.statusCode = 200
+    res.setHeader('Content-Type', 'application/json')
+    res.json(primaryAlias)
+  } catch (error) {
+    console.error(error)
+    res.status(error.status || 500).end(error.message)
+  }
+}
+
+export default handler

--- a/pages/api/ids/[name].ts
+++ b/pages/api/ids/[name].ts
@@ -1,21 +1,5 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
-import { getNonSigningClient } from 'hooks/cosmwasm'
-
-const CONTRACT = process.env.NEXT_PUBLIC_WHOAMI_ADDRESS as string
-
-const getNftInfo = async (tokenId: string) => {
-  const nonSigningClient = await getNonSigningClient()
-  try {
-    let nftInfo = await nonSigningClient.queryContractSmart(CONTRACT, {
-      all_nft_info: {
-        token_id: tokenId,
-      },
-    })
-    return nftInfo
-  } catch (e) {
-    return null
-  }
-}
+import { getNftInfo } from 'util/query'
 
 const handler = async (req: VercelRequest, res: VercelResponse) => {
   const { name } = req.query

--- a/util/conversion.tsx
+++ b/util/conversion.tsx
@@ -1,3 +1,13 @@
+import { bech32 } from 'bech32'
+import * as R from 'ramda'
+
+const DENOM = process.env.NEXT_PUBLIC_CHAIN_BECH32_PREFIX || 'juno'
+
+export const getDenom = () => R.toLower(DENOM)
+
+export const getJunoAddress = (cosmosAddress: string) =>
+  bech32.encode(getDenom(), bech32.decode(cosmosAddress).words)
+
 export function convertMicroDenomToDenom(amount: number | string) {
   if (typeof amount === 'string') {
     amount = Number(amount)

--- a/util/query.ts
+++ b/util/query.ts
@@ -1,0 +1,47 @@
+import { getNonSigningClient } from 'hooks/cosmwasm'
+
+const CONTRACT = process.env.NEXT_PUBLIC_WHOAMI_ADDRESS as string
+
+export const getNftInfo = async (tokenId: string) => {
+  const nonSigningClient = await getNonSigningClient()
+  try {
+    let nftInfo = await nonSigningClient.queryContractSmart(CONTRACT, {
+      all_nft_info: {
+        token_id: tokenId,
+      },
+    })
+    return nftInfo
+  } catch (e) {
+    return null
+  }
+}
+
+export const getPrimaryAlias = async (address: string) => {
+  const nonSigningClient = await getNonSigningClient()
+  try {
+    let aliasResponse = await nonSigningClient.queryContractSmart(CONTRACT, {
+      primary_alias: {
+        address: address,
+      },
+    })
+    return aliasResponse
+  } catch (e) {
+    return null
+  }
+}
+
+export const getTokens = async (address: string, limit: number = 30) => {
+  const nonSigningClient = await getNonSigningClient()
+  try {
+    let tokenList = await nonSigningClient.queryContractSmart(CONTRACT, {
+      tokens: {
+        owner: address,
+        limit: limit,
+      },
+    })
+
+    return tokenList
+  } catch (e) {
+    return []
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -918,6 +918,11 @@ bech32@^1.1.3, bech32@^1.1.4:
   resolved "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz"
   integrity sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==
 
+bech32@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/bech32/-/bech32-2.0.0.tgz#078d3686535075c8c79709f054b1b226a133b355"
+  integrity sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg==
+
 big.js@^5.2.2:
   version "5.2.2"
   resolved "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz"


### PR DESCRIPTION
Closes #123 

These API endpoints allow address lookups. They're also generic for cosmos IDs from different chains.